### PR TITLE
BUGFIX: 修正了cd时对特殊路径.和..的行为

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,8 @@ Cargo.lock
 # for eclipse
 .project
 
+# for vscode
 .vscode
+
+# for vim
+*.swp


### PR DESCRIPTION
之前`cd ..`会直接变成`$(cwd)..`，这显然不够合理。更普遍的情况是在路径中多次出现了`.`和`..`。

修复了这个bug，现在能正确显示当前目录的绝对路径了。