### PR TITLE
Fix fnctl nonblock check

### DIFF
--- a/kernel/src/fs/file.rs
+++ b/kernel/src/fs/file.rs
@@ -146,7 +146,7 @@ impl FileHandle {
     }
 
     pub fn fcntl(&mut self, cmd: usize, arg: usize) -> Result<()> {
-        if arg == 2048 && cmd == 4 {
+        if arg & 0x800 > 0 && cmd == 4 {
             self.options.nonblock = true;
         }
         Ok(())

--- a/kernel/src/syscall/mem.rs
+++ b/kernel/src/syscall/mem.rs
@@ -60,7 +60,7 @@ impl Syscall<'_> {
                     #[cfg(feature = "board_raspi3")]
                     let attr = attr.mmio(crate::arch::paging::MMIOType::NormalNonCacheable as u8);
 
-                    if let Some(fb) = FRAME_BUFFER.lock().as_mut() {
+                    if let Some(fb) = FRAME_BUFFER.lock().as_ref() {
                         self.vm().push(
                             addr,
                             addr + len,


### PR DESCRIPTION
musl will add extra flags when set `arg` to `O_NONBLOCK` for non-x86 architecture