### PR TITLE
Fix peripherals memory mapping

### DIFF
--- a/kernel/src/arch/aarch64/memory.rs
+++ b/kernel/src/arch/aarch64/memory.rs
@@ -89,7 +89,7 @@ fn map_kernel() {
         super::board::PERIPHERALS_START,
         super::board::PERIPHERALS_END,
         MemoryAttr::default().mmio(MMIOType::Device as u8),
-        Linear::new(offset),
+        Linear::new(0),
         "peripherals",
     );
 


### PR DESCRIPTION
Since `PERIPHERALS_START` and `PERIPHERALS_END` hasn't `KERNEL_OFFSET`, there's no need to minus it.